### PR TITLE
Update to version 7 of .net sdk

### DIFF
--- a/NextGen/apsimng-build/Dockerfile
+++ b/NextGen/apsimng-build/Dockerfile
@@ -31,7 +31,7 @@ rm packages-microsoft-prod.deb
 RUN echo "deb http://deb.debian.org/debian testing main" >>/etc/apt/sources.list && \
     apt update && \
     apt install -y -t testing rsync && \
-    apt install -y dotnet-sdk-3.1 genisoimage cmake
+    apt install -y dotnet-sdk-7.0 genisoimage cmake
 
 # Manually install a cut-down version of libdmg-hfsplus, which contains only the
 # dmg tool which will compress our .dmg mac installer.


### PR DESCRIPTION
See the discussion on APSIMInitiative/ApsimX#7731 for the reasoning.

I've tested this and can still build the master branch on the updated image. After merging, someone with push access to the apsiminitiative docker organisation will need to build the updated image and push it to dockerhub.