### PR TITLE
Updated Runtime Install To 6.0

### DIFF
--- a/NextGen/apsimng/Dockerfile
+++ b/NextGen/apsimng/Dockerfile
@@ -33,7 +33,7 @@ RUN dotnet publish --nologo -c Release -f net6.0 -r linux-x64 --no-self-containe
 
 # The actual image is based on dotnet/runtime.
 # docker build <build args> --target apsimng -t apsiminitiative/apsimng:latest .
-FROM mcr.microsoft.com/dotnet/runtime:3.1-bullseye-slim as apsimng
+FROM mcr.microsoft.com/dotnet/runtime:6.0-bullseye-slim as apsimng
 
 # Install sqlite3
 RUN apt update -q --silent && \


### PR DESCRIPTION
Latest Docker Image only installed .Net 3.1 but was trying to target 6.0

This seems to be the line that was missed, was able to build and run the docker image with this change.