### PR TITLE
Added target to produce ApsimNG GUI container

### DIFF
--- a/NextGen/apsimng/Dockerfile
+++ b/NextGen/apsimng/Dockerfile
@@ -88,3 +88,24 @@ FROM apsimng as apsimng-server
 COPY --from=build-server /apsim/bin/Release/net6.0/linux-x64/publish /opt/apsim/
 
 ENTRYPOINT ["apsim-server"]
+
+
+# Build the GUI in another intermediate image
+FROM build as build-apsimng-gui
+
+RUN dotnet publish -c Release -f net6.0 -r linux-x64 --no-self-contained /apsim/ApsimNG/ApsimNG.csproj
+
+
+# GUI image uses apsimng as base image
+# docker build <build args> --target apsimng-gui -t apsiminitiative/apsimng-gui:latest .
+FROM apsimng as apsimng-gui
+
+# Copy build artifacts from the intermediate container to /opt/apsim
+COPY --from=build-apsimng-gui /apsim/bin/Release/net6.0/linux-x64/publish/ /opt/apsim/
+
+# Install graphical libraries.
+RUN apt update -q --silent &&                                                  \
+    apt install -yq gtk-sharp3                                                 \
+                    libgtksourceview-4-0
+
+ENTRYPOINT ["ApsimNG"]

--- a/NextGen/apsimng/apsim-gui.sh
+++ b/NextGen/apsimng/apsim-gui.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+readonly SCRIPTNAME=$(basename "${0%.sh}")
+usage() {
+    cat <<-END
+NAME
+      ${SCRIPTNAME} - Run a graphical APSIM Next Gen instance via Docker.
+
+SYNOPSIS
+       ${SCRIPTNAME} [OPTION]...
+
+DESCRIPTION
+       Run APSIM Next Gen GUI in a Docker container.
+
+USAGE
+       Launch an APSIM Next Gen graphical session with the current directory
+       mounted into the container as '/data':
+
+              apsimng-gui.sh
+
+       Launch an APSIM Next Gen graphical session with a specified directory
+       mounted into the container as '/data':
+
+              apsimng-gui.sh --data=./project
+
+OPTIONS SUMMARY
+       --data            Optional. Directory to mount as '/data'. If not
+                         specified, the current/working directory will be used.
+       -h, --help        Display this help and exit.
+
+AUTHOR
+       Written by Asher Bender.
+
+SEE ALSO
+       For more information on APSIM Next Gen visit: <https://www.apsim.info/apsim-next-generation/>
+       For APSIM Docker containers visit: <https://hub.docker.com/u/apsiminitiative>
+
+END
+}
+
+readonly IMAGE_TAG="apsiminitiative/apsimng-gui:latest"
+
+# ------------------------------------------------------------------------------
+#                                 Parse options
+# ------------------------------------------------------------------------------
+
+# Define command line argument/options.
+OPTIONS="hv"
+LONGOPTS="data:,help"
+
+# Parse options and exit on failures.
+! OPTS=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
+if [[ ${PIPESTATUS[0]} -ne 0 ]]; then
+    exit 1
+fi
+eval set -- "$OPTS"
+
+# Collect options.
+DATA=$(pwd)
+while true; do
+    case "$1" in
+        --data)          DATA="$2"; shift 2;;
+        -h | --help)     usage; exit 0 ;;
+        -- ) shift; break ;;
+        * ) break ;;
+    esac
+done
+
+# Convert data directory to absolute path and ensure it exists.
+DATA=$(realpath ${DATA})
+if [ ! -d ${DATA} ]; then
+    echo "The data directory does not exist: ${DATA}."
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------
+#                                 Run container
+# ------------------------------------------------------------------------------
+
+xhost +local:docker
+docker run --rm -it                                                            \
+           -u $(id -u):$(id -g)                                                \
+           -e DISPLAY=unix$DISPLAY                                             \
+           -v /tmp/.X11-unix:/tmp/.X11-unix                                    \
+           -v /etc/localtime:/etc/localtime:ro                                 \
+           -v  ${DATA}:/data                                                   \
+           -v  /dev/shm:/ApsimInitiative/ApsimX                                \
+           ${IMAGE_TAG}


### PR DESCRIPTION
This pull requests implements a new Docker build target called `apsimng-gui`. The container hosts the APSIM Next Gen graphical  interface in a Debian Bullseye OS (same as the `apsimng` container). The container can be built by issuing the command:

`docker build <build args> --target apsimng-gui -t apsiminitiative/apsimng-gui:latest .`

If this pull request is accepted and the graphical container is a useful addition, it will need to be added to the [Jenkins build scripts](https://github.com/APSIMInitiative/Jenkins/blob/master/NextGen/deploy-docker). 