### PR TITLE
Add options to Docker launch script.

### DIFF
--- a/NextGen/apsimng/apsim-gui.sh
+++ b/NextGen/apsimng/apsim-gui.sh
@@ -13,20 +13,46 @@ DESCRIPTION
        Run APSIM Next Gen GUI in a Docker container.
 
 USAGE
-       Launch an APSIM Next Gen graphical session with the current directory
-       mounted into the container as '/data':
+       Launch a Docker container (apsiminitiative/apsimng-gui:latest) running an
+       APSIM Next Gen graphical session.
 
               apsimng-gui.sh
 
-       Launch an APSIM Next Gen graphical session with a specified directory
-       mounted into the container as '/data':
+       Note that the current directory is mounted into the container as '/data'.
+       A directory on the host machine can mounted into the container using the
+       '--data' option:
 
               apsimng-gui.sh --data=./project
 
+       To use a specific image tag (apsiminitiative/apsimng-gui:tag), specify
+       the tag via the '--tag' option:
+
+              apsimng-gui.sh --tag 7446
+
+       If '--tag' is omitted, 'latest' will be used.
+
+       Local and remote images can be synchronised using the '--update'
+       option. For example, to ensure the local 'latest' image matches the
+       remote 'latest' image, run:
+
+              apsimng-gui.sh --update
+
+
 OPTIONS SUMMARY
-       --data            Optional. Directory to mount as '/data'. If not
-                         specified, the current/working directory will be used.
-       -h, --help        Display this help and exit.
+       --tag       Optional. Specify the image:tag (apsiminitiative/apsimng-gui)
+                   to run. If the image tag is not available in the local Docker
+                   register, the script will search the remote Docker register
+                   (Docker Hub) and pull the image if available. If the tag does
+                   not exist locally or on the remote registry, the script will
+                   exit. By default the tag is set to 'latest'.
+       --update    Optional. If this flag is set and the image tag exists on
+                   both the local and remote registries, the remote image will
+                   be pulled if the digest sha256 hashes do not match. This flag
+                   can be used to ensure local and remote tags, like 'latest',
+                   are synchronised.
+       --data      Optional. Directory to mount as '/data'. If not specified,
+                   the current/working directory will be used.
+       -h, --help  Display this help and exit.
 
 AUTHOR
        Written by Asher Bender.
@@ -38,7 +64,86 @@ SEE ALSO
 END
 }
 
-readonly IMAGE_TAG="apsiminitiative/apsimng-gui:latest"
+readonly DOCKER_HUB="https://registry.hub.docker.com/v2/repositories"
+readonly IMAGE="apsiminitiative/apsimng-gui"
+
+# ------------------------------------------------------------------------------
+#                              Script dependencies
+# ------------------------------------------------------------------------------
+
+if ! command -v docker &> /dev/null ; then
+    echo "This script requires Docker to be installed."
+    exit 1
+fi
+
+if ! command -v getopt &> /dev/null ; then
+    echo "This script requires 'getopt' to be installed."
+    exit 1
+fi
+
+if ! command -v jq &> /dev/null ; then
+    echo "This script requires 'jq' to be installed."
+    exit 1
+fi
+
+# ------------------------------------------------------------------------------
+#                                Local functions
+# ------------------------------------------------------------------------------
+
+get_local_hash(){
+    # Return the hash of a local image.
+    #
+    # Query the local registry for an image and tag. If a manifest is returned,
+    # it is parsed and the sha256 digest is returned. If no manifest is found,
+    # an empty string is returned.
+    #
+    # Args:
+    #     image (str): Name of image on remote registry (Docker Hub).
+    #     tag   (str): Tag of image.
+    #
+    # Returns:
+    #     str: sha256 digest if the `image` and `tag` exist on the remote
+    #     registry, otherwise the empty string is returned.
+
+    local image="$1"
+    local tag="$2"
+
+    manifest=$(docker inspect "${IMAGE}:${TAG}" 2>/dev/null)
+
+    if [[ $? -eq 0 ]]; then
+        echo "${manifest}" | jq -r '.[].Id'
+    else
+        echo ""
+    fi
+}
+
+
+get_remote_hash(){
+    # Return the hash of a remote image.
+    #
+    # Query the remote registry (Docker Hub) for an image and tag. If a manifest
+    # is returned, it is parsed and the sha256 digest is returned. If no
+    # manifest is found, an empty string is returned.
+    #
+    # Args:
+    #     image (str): Name of image on remote registry (Docker Hub).
+    #     tag   (str): Tag of image.
+    #
+    # Returns:
+    #     str: sha256 digest if the `image` and `tag` exist on the remote
+    #     registry, otherwise the empty string is returned.
+
+    local image="$1"
+    local tag="$2"
+
+    manifest=$(docker manifest inspect ${image}:${tag} 2>/dev/null)
+
+    if [[ $? -eq 0 ]]; then
+        echo "${manifest}" | jq -r '.config.digest'
+    else
+        echo ""
+    fi
+}
 
 # ------------------------------------------------------------------------------
 #                                 Parse options
@@ -46,7 +151,7 @@ readonly IMAGE_TAG="apsiminitiative/apsimng-gui:latest"
 
 # Define command line argument/options.
 OPTIONS="hv"
-LONGOPTS="data:,help"
+LONGOPTS="tag:,update,data:,help"
 
 # Parse options and exit on failures.
 ! OPTS=$(getopt --options=$OPTIONS --longoptions=$LONGOPTS --name "$0" -- "$@")
@@ -56,11 +161,15 @@ fi
 eval set -- "$OPTS"
 
 # Collect options.
+TAG='latest'
 DATA=$(pwd)
+UPDATE=0
 while true; do
     case "$1" in
-        --data)          DATA="$2"; shift 2;;
-        -h | --help)     usage; exit 0 ;;
+        --tag)    TAG="$2";  shift 2;;
+        --update) UPDATE=1;  shift ;;
+        --data)   DATA="$2"; shift 2;;
+        -h | --help) usage; exit 0 ;;
         -- ) shift; break ;;
         * ) break ;;
     esac
@@ -74,9 +183,71 @@ if [ ! -d ${DATA} ]; then
 fi
 
 # ------------------------------------------------------------------------------
-#                                 Run container
+#                              Acquire/update image
 # ------------------------------------------------------------------------------
 
+echo "Searching registries for '${IMAGE}:${TAG}'."
+echo -n "    Searching local  registry."
+local_hash=$(get_local_hash "${IMAGE}" "${TAG}")
+
+# Check local repository for image.
+if [ ! -z "${local_hash}" ]; then
+    echo " Image found."
+else
+    echo " Image not found".
+fi
+
+# If the local repository does not exist OR the local repository exists and the
+# user has requested an update.
+remote_hash=""
+if [ -z "${local_hash}" ] || { [ ! -z "${local_hash}" ] && [ ${UPDATE} -eq 1 ]; }; then
+    echo -n "    Searching remote registry."
+    remote_hash=$(get_remote_hash "${IMAGE}" "${TAG}")
+
+    if [ ! -z "${remote_hash}" ]; then
+        echo " Image found."
+    else
+        echo " Image not found".
+    fi
+fi
+
+
+# The image could be found on both the local and remote registries.
+if [ ! -z "${local_hash}" ] && [ ! -z "${remote_hash}" ]; then
+
+    if [[ "${local_hash}" == "${remote_hash}" ]] ; then
+        echo "    The local and remote images have an identical hash."
+        echo "        local:  ${local_hash}"
+        echo "        remote: ${remote_hash}"
+    else
+        echo "    The local and remote images have different hashes."
+        echo "        local:  ${local_hash}"
+        echo "        remote: ${remote_hash}"
+        if [ ${UPDATE} -eq 1 ] ; then
+            echo "    Pulling remote image."
+            docker pull "${IMAGE}:${TAG}"
+        fi
+    fi
+
+# The image could only be found on the remote registry.
+elif [ -z "${local_hash}" ] && [ ! -z "${remote_hash}" ]; then
+    echo "Pulling remote image."
+    docker pull "${IMAGE}:${TAG}"
+
+# The image could not be found on either the local or remote registries.
+elif [ -z "${local_hash}" ] && [ -z "${remote_hash}" ]; then
+    echo "The image '${IMAGE}:${TAG}' could not be found."
+    exit 1
+
+# The image could only be found on the local registry. This condition should not
+# happen. We know 'apsiminitiative/apsimng-gui' exists! Use local image.
+else
+    :
+fi
+
+# ------------------------------------------------------------------------------
+#                                 Run container
+# ------------------------------------------------------------------------------
 xhost +local:docker
 docker run --rm -it                                                            \
            -u $(id -u):$(id -g)                                                \
@@ -85,4 +256,4 @@ docker run --rm -it                                                            \
            -v /etc/localtime:/etc/localtime:ro                                 \
            -v  ${DATA}:/data                                                   \
            -v  /dev/shm:/ApsimInitiative/ApsimX                                \
-           ${IMAGE_TAG}
+           ${IMAGE}:${TAG}


### PR DESCRIPTION
This pull request introduces two changes to the APSIM Next Gen [Docker launch script](NextGen/apsimng/apsim-gui.sh):

- Allow user to specify a specific tag to run.
- Allow user to synchronise local and remote tags (e.g. latest).

When specifying a tag that does not exist, the tag is automatically downloaded before launching the GUI:

```shell
./apsim-gui.sh --tag 7445

Searching registries for 'apsiminitiative/apsimng-gui:7445'.
    Searching local  registry. Image not found.
    Searching remote registry. Image found.
Pulling remote image.
7445: Pulling from apsiminitiative/apsimng-gui
04e7578caeaa: Already exists 
f58cc51ecd71: Already exists 
bcb5bb2e7465: Already exists 
06802a4e8a79: Already exists 
830d2ca51a02: Pull complete 
db8d7478d5e8: Pull complete 
8f09688d28b1: Pull complete 
8928b267ba7b: Pull complete 
Digest: sha256:f2c5fcb1199b6c085922d81b36f447c8d1949b2e176797ef0fc4740d7c96d3b4
Status: Downloaded newer image for apsiminitiative/apsimng-gui:7445

```

To synchronise local and remote tags (e.g. `latest`), the `--update` flag can be used:

```shell
./apsim-gui.sh --update         
                          
Searching registries for 'apsiminitiative/apsimng-gui:latest'.
    Searching local  registry. Image found.
    Searching remote registry. Image found.
    The local and remote images have different hashes.
        local:  sha256:95d95c75f178ee9875ded5945ea931709355a612fd0660d2a80db549db2eff56
        remote: sha256:faf1a894d1c936d41dcfe5940c1de7f65af6d78567e7185e7bf90787f3c1154e
    Pulling remote image.
latest: Pulling from apsiminitiative/apsimng-gui
Digest: sha256:5bea520dd9d8d7c7d7f750389908da3e1c180354a73482dc643e36d8adb04f20
Status: Downloaded newer image for apsiminitiative/apsimng-gui:latest
docker.io/apsiminitiative/apsimng-gui:latest

```